### PR TITLE
Fix for change in raster package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,6 @@
 Package: bcmaps
 Title: Map Layers and Spatial Utilities for British Columbia
 Version: 0.17.0.9000
-Date: 2018-01-17
 Authors@R: c(person("Andy", "Teucher", email = "andy.teucher@gov.bc.ca",
   role = c("aut", "cre")), person("Stephanie", "Hazlitt", email = "stephanie.hazlitt@gov.bc.ca",
   role = "aut"), person("Sam", "Albers", email = "sam.albers@gov.bc.ca", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bcmaps
 Title: Map Layers and Spatial Utilities for British Columbia
-Version: 0.17.0.9000
+Version: 0.17.1
 Authors@R: c(person("Andy", "Teucher", email = "andy.teucher@gov.bc.ca",
   role = c("aut", "cre")), person("Stephanie", "Hazlitt", email = "stephanie.hazlitt@gov.bc.ca",
   role = "aut"), person("Sam", "Albers", email = "sam.albers@gov.bc.ca", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,6 @@ Description: Provides access to various spatial layers for B.C., such as
     through function calls in this package. All layers are in B.C. 'Albers' equal-area projection 
     <http://spatialreference.org/ref/epsg/nad83-bc-albers/>, which is the B.C. 
     government standard.
-Depends:
-    R (>= 3.4.0)
 Imports: 
     methods,
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ BugReports: https://github.com/bcgov/bcmaps/issues
 LazyData: true
 RoxygenNote: 6.0.1
 Suggests:
-    bcmaps.rdata (>= 0.1.3),
+    bcmaps.rdata (>= 0.1.5),
     knitr,
     rmarkdown,
     sp (>= 1.2-5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,32 +11,32 @@ Description: Provides access to various spatial layers for B.C., such as
     through function calls in this package. All layers are in B.C. 'Albers' equal-area projection 
     <http://spatialreference.org/ref/epsg/nad83-bc-albers/>, which is the B.C. 
     government standard.
-Imports: 
-    methods,
-    utils,
-    stats,
-    sf (>= 0.5-4),
-    rappdirs (>= 0.3.1),
-    httr (>= 1.3.1)
 License: Apache License (== 2.0) | file LICENSE
 URL: https://github.com/bcgov/bcmaps
 BugReports: https://github.com/bcgov/bcmaps/issues
-LazyData: true
-RoxygenNote: 6.0.1
-Suggests:
+Imports: 
+    httr (>= 1.3.1),
+    methods,
+    rappdirs (>= 0.3.1),
+    sf (>= 0.5-4),
+    stats,
+    utils
+Suggests: 
     bcmaps.rdata (>= 0.1.5),
-    knitr,
-    rmarkdown,
-    sp (>= 1.2-5),
-    rgdal (>= 1.2-13),
-    rgeos (>= 0.3-25),
-    raster (>= 2.5-8),
+    doMC (>= 1.3.4),
     ggplot2 (>= 2.2.1),
     glue (>= 1.1.1),
-    doMC (>= 1.3.4),
-    plyr (>= 1.8.4),
+    knitr,
     lwgeom (>= 0.1-2),
+    plyr (>= 1.8.4),
+    raster (>= 2.5-8),
+    rgdal (>= 1.2-13),
+    rgeos (>= 0.3-25),
+    rmarkdown,
+    sp (>= 1.2-5),
     testthat
-Additional_repositories: https://bcgov.github.io/drat
 VignetteBuilder: knitr
+Additional_repositories: https://bcgov.github.io/drat
+LazyData: true
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 6.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# bcmaps v0.17.0.9000
+# bcmaps v0.17.1
+* Fixed an issue where `self_union()` would fail due to a change in the `raster` package (30cef3438)
 
 # bcmaps 0.17.0
 * Output of `available_layers()` has changed: `shortcut_function` column is now logical, uses better column names, and has a custom print function that gives more information. (#34)

--- a/R/raster_by_poly.R
+++ b/R/raster_by_poly.R
@@ -1,16 +1,20 @@
-#' Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer and clip the raster to each polygon.
+#' Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer
+#' and clip the raster to each polygon.
 #'
 #' @param raster_layer the raster layer
 #' @param poly a `SpatialPolygonsDataFrame` layer or `sf` layer
 #' @param poly_field the field on which to split the `SpatialPolygonsDataFrame`
-#' @param summarize Should the function summarise the raster values in each polygon to a vector? Default `FALSE`
-#' @param parallel process in parallel? Default `FALSE`
-#' @param cores number of cores if doing parallel. Default `NULL` uses half the number detected
+#' @param summarize Should the function summarise the raster values in each
+#'     polygon to a vector? Default `FALSE`
+#' @param parallel process in parallel? Default `FALSE`. Not currently
+#'     available on Windows.
+#' @param cores number of cores if doing parallel. Default `NULL` uses half the
+#'     number detected
 #' @param ... passed on to `doMC::registerDoMC`
 #'
-#' @return a list of `RasterLayers` if `summarize = FALSE` otherwise a list of vectors.
+#' @return a list of `RasterLayers` if `summarize = FALSE` otherwise a list of
+#'     vectors.
 #' @export
-#'
 raster_by_poly <- function(raster_layer, poly, poly_field, summarize = FALSE,
                            parallel = FALSE, cores = NULL, ...) {
 
@@ -63,8 +67,12 @@ check_inputs <- function(parallel, cores, ...) {
   # Make this work on windows:
   # https://stackoverflow.com/questions/6780091/simple-working-example-of-ddply-in-parallel-on-windows
   if (parallel) {
-    if (.Platform$OS.type == "windows") stop("Parallel is currently not supported on Windows")
-    if (!requireNamespace("doMC")) stop("package doMC required for parallel processing")
+    if (.Platform$OS.type == "windows") {
+      stop("Parallel is currently not supported on Windows")
+    }
+    if (!requireNamespace("doMC")) {
+      stop("package doMC required for parallel processing")
+    }
     doMC::registerDoMC(cores = cores, ...)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -356,7 +356,7 @@ combine_nr_rd <- function(class = c("sf", "sp")) {
   rbind(rd, mun[mun$ADMIN_AREA_ABBREVIATION == "NRRM",])
 }
 
-
+#' @noRd
 ask <- function(...) {
   choices <- c("Yes", "No")
   cat(paste0(..., collapse = ""))

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,8 +30,8 @@
 #' ## Get the area of the land only, in hectares:
 #' bc_area("land", "ha")
 bc_area <- function(what = "total", units = "km2") {
-  what = match.arg(what, c("total", "land", "freshwater"))
-  units = match.arg(units, c("km2", "m2", "ha", "acres", "sq_mi"))
+  what <- match.arg(what, c("total", "land", "freshwater"))
+  units <- match.arg(units, c("km2", "m2", "ha", "acres", "sq_mi"))
 
   val_km2 <- switch(what, total = 944735, land = 925186, freshwater = 19549)
   ret <- switch(units, km2 = val_km2, m2 = km2_m2(val_km2), ha = km2_ha(val_km2),
@@ -350,7 +350,7 @@ get_return_type <- function(x) {
 #' combined with the Regional Districts to form a full provincial coverage.
 #' @export
 combine_nr_rd <- function(class = c("sf", "sp")) {
-  class = match.arg(class)
+  class <- match.arg(class)
   rd <- get_layer("regional_districts", class = class)
   mun <- get_layer("municipalities", class = class)
   rbind(rd, mun[mun$ADMIN_AREA_ABBREVIATION == "NRRM",])

--- a/R/utils.R
+++ b/R/utils.R
@@ -248,7 +248,9 @@ raster_union <- function(x) {
   f <- methods::getMethod("union", c("SpatialPolygons", "missing"))
   # Find the offending block in the body, and replace it with NULL
   the_prob <- which(grepl("!rgeos::gIntersects(x)", body(f), fixed = TRUE))
-  body(f)[[the_prob]] <- NULL
+  if (length(the_prob)) {
+    body(f)[[the_prob]] <- NULL
+  }
   # Call the modified function with the input
   f(x)
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,37 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file and re-knit-->
-bcmaps <img src="tools/readme/bcmaps-sticker.png" height="139" align="right"/>
-==============================================================================
 
-### Version 0.17.0.9000
+# bcmaps <img src="tools/readme/bcmaps-sticker.png" height="139" align="right"/>
 
-<a id="devex-badge" rel="Delivery" href="https://github.com/BCDevExchange/assets/blob/master/README.md"><img alt="In production, but maybe in Alpha or Beta. Intended to persist and be supported." style="border-width:0" src="https://assets.bcdevexchange.org/images/badges/delivery.svg" title="In production, but maybe in Alpha or Beta. Intended to persist and be supported." /></a> [![Travis-CI Build Status](https://travis-ci.org/bcgov/bcmaps.svg?branch=master)](https://travis-ci.org/bcgov/bcmaps) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/bcmaps)](https://cran.r-project.org/package=bcmaps) [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/bcmaps)](https://CRAN.R-project.org/package=bcmaps)
+### Version 0.17.1
 
-Overview
---------
+<a id="devex-badge" rel="Delivery" href="https://github.com/BCDevExchange/assets/blob/master/README.md"><img alt="In production, but maybe in Alpha or Beta. Intended to persist and be supported." style="border-width:0" src="https://assets.bcdevexchange.org/images/badges/delivery.svg" title="In production, but maybe in Alpha or Beta. Intended to persist and be supported." /></a>
+[![Travis-CI Build
+Status](https://travis-ci.org/bcgov/bcmaps.svg?branch=master)](https://travis-ci.org/bcgov/bcmaps)
+[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/bcmaps)](https://cran.r-project.org/package=bcmaps)
+[![CRAN
+Downloads](http://cranlogs.r-pkg.org/badges/grand-total/bcmaps)](https://CRAN.R-project.org/package=bcmaps)
 
-An [R](http://r-project.org) package of spatial map layers for British Columbia.
+## Overview
 
-Features
---------
+An [R](http://r-project.org) package of spatial map layers for British
+Columbia.
 
-Provides access to various spatial layers of British Columbia, such as administrative boundaries, natural resource management boundaries, watercourses etc. All layers are available in the [BC Albers](http://spatialreference.org/ref/epsg/nad83-bc-albers/) projection, which is the B.C. Government standard as `sf` or `Spatial` objects.
+## Features
 
-Layers are stored in the [bcmaps.rdata](https://github.com/bcgov/bcmaps.rdata) package and loaded by this package, following the strategy recommended by [Anderson and Eddelbuettel](https://journal.r-project.org/archive/2017/RJ-2017-026/index.html).
+Provides access to various spatial layers of British Columbia, such as
+administrative boundaries, natural resource management boundaries,
+watercourses etc. All layers are available in the [BC
+Albers](http://spatialreference.org/ref/epsg/nad83-bc-albers/)
+projection, which is the B.C. Government standard as `sf` or `Spatial`
+objects.
 
-Installation
-------------
+Layers are stored in the
+[bcmaps.rdata](https://github.com/bcgov/bcmaps.rdata) package and loaded
+by this package, following the strategy recommended by [Anderson and
+Eddelbuettel](https://journal.r-project.org/archive/2017/RJ-2017-026/index.html).
+
+## Installation
 
 You can install `bcmaps` from CRAN:
 
@@ -28,25 +39,30 @@ You can install `bcmaps` from CRAN:
 install.packages("bcmaps")
 ```
 
-To install the development version of the `bcmaps` package, you need to install the `remotes` package then the `bcmaps` package.
+To install the development version of the `bcmaps` package, you need to
+install the `remotes` package then the `bcmaps` package.
 
 ``` r
 install.packages("remotes")
 remotes::install_github("bcgov/bcmaps")
 ```
 
-Usage
------
+## Usage
 
-To get full usage of the package, you will also need to install the [**bcmaps.rdata**](https://github.com/bcgov/bcmaps.rdata) package, which holds all of the datasets.
+To get full usage of the package, you will also need to install the
+[**bcmaps.rdata**](https://github.com/bcgov/bcmaps.rdata) package, which
+holds all of the datasets.
 
-*Note that unlike most packages it is not necessary to actually load the **bcmaps.rdata** package (i.e., with `library(bcmaps.rdata)`) - in fact it is less likely to cause problems if you don't.*
+*Note that unlike most packages it is not necessary to actually load the
+**bcmaps.rdata** package (i.e., with `library(bcmaps.rdata)`) - in fact
+it is less likely to cause problems if you don’t.*
 
 ``` r
 install.packages('bcmaps.rdata', repos='https://bcgov.github.io/drat/')
 ```
 
-To see the layers that are available, run the `available_layers()` function:
+To see the layers that are available, run the `available_layers()`
+function:
 
 ``` r
 library(bcmaps)
@@ -128,19 +144,25 @@ available_layers()
 #> on your hard drive.
 ```
 
-Most layers are accessible by a shortcut function by the same name as the object. Then you can use the data as you would any `sf` or `Spatial` object. For example:
+Most layers are accessible by a shortcut function by the same name as
+the object. Then you can use the data as you would any `sf` or `Spatial`
+object. For example:
 
 ``` r
 library(sf)
-#> Linking to GEOS 3.6.2, GDAL 2.2.3, proj.4 4.9.3
+#> Linking to GEOS 3.6.1, GDAL 2.1.3, proj.4 4.9.3
 
 bc <- bc_bound()
 plot(st_geometry(bc))
 ```
 
-![](tools/readme/unnamed-chunk-6-1.png)
+![](tools/readme/unnamed-chunk-6-1.png)<!-- -->
 
-Alternatively, you can use the `get_layer` function - simply type `get_layer('layer_name')`, where `'layer_name'` is the name of the layer of interest. The `get_layer` function is useful if the back-end `bcmaps.rdata` package has had a layer added to it, but there is as yet no shortcut function created in `bcmaps`.
+Alternatively, you can use the `get_layer` function - simply type
+`get_layer('layer_name')`, where `'layer_name'` is the name of the layer
+of interest. The `get_layer` function is useful if the back-end
+`bcmaps.rdata` package has had a layer added to it, but there is as yet
+no shortcut function created in `bcmaps`.
 
 ``` r
 library(sf)
@@ -151,11 +173,12 @@ ws <- get_layer("wsc_drainages", class = "sf")
 plot(ws["SUB_SUB_DRAINAGE_AREA_NAME"], key.pos = NULL)
 ```
 
-![](tools/readme/unnamed-chunk-7-1.png)
+![](tools/readme/unnamed-chunk-7-1.png)<!-- -->
 
 ### Simple Features objects
 
-By default, all layers are returned as [`sf` spatial objects](https://cran.r-project.org/package=sf):
+By default, all layers are returned as [`sf` spatial
+objects](https://cran.r-project.org/package=sf):
 
 ``` r
 library(bcmaps)
@@ -172,11 +195,13 @@ kootenays <- rd[rd$ADMIN_AREA_NAME == "Regional District of Central Kootenay", ]
 plot(st_geometry(kootenays), col = "lightseagreen", add = TRUE)
 ```
 
-![](tools/readme/plot-maps-1.png)
+![](tools/readme/plot-maps-1.png)<!-- -->
 
 ### Spatial (sp) objects
 
-If you aren't using the `sf` package and prefer the old standard [`sp`](https://cran.r-project.org/package=sp) way of doing things, set `class = "sp"` in either `get_layer` or the shortcut functions:
+If you aren’t using the `sf` package and prefer the old standard
+[`sp`](https://cran.r-project.org/package=sp) way of doing things, set
+`class = "sp"` in either `get_layer` or the shortcut functions:
 
 ``` r
 library("sp")
@@ -185,11 +210,14 @@ plot(get_layer("bc_bound", class = "sp"))
 plot(watercourses_15M(class = "sp"), add = TRUE)
 ```
 
-![](tools/readme/watercourses-1.png)
+![](tools/readme/watercourses-1.png)<!-- -->
 
 ### Biogeoclimatic Zones
 
-As of version 0.15.0 the B.C. BEC (Biogeoclimatic Ecosystem Classification) map is available via the `bec()` function, and an accompanying function `bec_colours()` function to colour it:
+As of version 0.15.0 the B.C. BEC (Biogeoclimatic Ecosystem
+Classification) map is available via the `bec()` function, and an
+accompanying function `bec_colours()` function to colour
+it:
 
 ``` r
 # This example requires the development version of ggplot2 which has the 
@@ -204,39 +232,55 @@ ggplot() +
   scale_colour_manual(values = bec_colours())
 ```
 
-![](tools/readme/bec-1.png)
+![](tools/readme/bec-1.png)<!-- -->
 
 ### Vignettes
 
-We have written a short vignette on plotting points on one of the layers from `bcmaps`. You can view the vignette online [here](https://cran.r-project.org/web/packages/bcmaps/vignettes/add_points.html) or if you installed the package you can open it using `browseVignettes("bcmaps")`.
+We have written a short vignette on plotting points on one of the layers
+from `bcmaps`. You can view the vignette online
+[here](https://cran.r-project.org/web/packages/bcmaps/vignettes/add_points.html)
+or if you installed the package you can open it using
+`browseVignettes("bcmaps")`.
 
 ### Utility Functions
 
 The package also contains a couple of handy utility functions:
 
-1.  `fix_geo_problems()` for fixing invalid topologies in `sf` or `Spatial` objects such as orphaned holes and self-intersections
-2.  `transform_bc_albers()` for transforming any `sf` or `Spatial` object to [BC Albers](https://epsg.io/3005) projection.
-3.  `self_union()` Union a `SpatialPolygons*` object with itself to remove overlaps, while retaining attributes
+1.  `fix_geo_problems()` for fixing invalid topologies in `sf` or
+    `Spatial` objects such as orphaned holes and self-intersections
+2.  `transform_bc_albers()` for transforming any `sf` or `Spatial`
+    object to [BC Albers](https://epsg.io/3005) projection.
+3.  `self_union()` Union a `SpatialPolygons*` object with itself to
+    remove overlaps, while retaining attributes
 
-Getting Help or Reporting an Issue
-----------------------------------
+## Getting Help or Reporting an Issue
 
-To report bugs/issues/feature requests, please file an [issue](https://github.com/bcgov/bcmaps/issues/).
+To report bugs/issues/feature requests, please file an
+[issue](https://github.com/bcgov/bcmaps/issues/).
 
-How to Contribute
------------------
+## How to Contribute
 
-Pull requests of new B.C. layers are welcome. If you would like to contribute to the package, please see our [CONTRIBUTING](https://github.com/bcgov/bcmaps/CONTRIBUTING.md) guidelines.
+Pull requests of new B.C. layers are welcome. If you would like to
+contribute to the package, please see our
+[CONTRIBUTING](https://github.com/bcgov/bcmaps/CONTRIBUTING.md)
+guidelines.
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/bcgov/bcmaps/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of
+Conduct](https://github.com/bcgov/bcmaps/CODE_OF_CONDUCT.md). By
+participating in this project you agree to abide by its terms.
 
-Source Data
------------
+## Source Data
 
-The source datasets used in this package come from various sources under open licences, including [DataBC](http://data.gov.bc.ca) ([Open Government Licence - British Columbia](http://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61)) and [Statistics Canada](http://www.statcan.gc.ca/start-debut-eng.html) ([Statistics Canada Open Licence Agreement](http://www.statcan.gc.ca/eng/reference/licence-eng)). See the `data-raw` folder for details on each source dataset.
+The source datasets used in this package come from various sources under
+open licences, including [DataBC](http://data.gov.bc.ca) ([Open
+Government Licence - British
+Columbia](http://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61))
+and [Statistics Canada](http://www.statcan.gc.ca/start-debut-eng.html)
+([Statistics Canada Open Licence
+Agreement](http://www.statcan.gc.ca/eng/reference/licence-eng)). See the
+`data-raw` folder for details on each source dataset.
 
-Licence
--------
+## Licence
 
     # Copyright 2017 Province of British Columbia
     # 
@@ -250,4 +294,7 @@ Licence
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and limitations under the License.
 
-This repository is maintained by [Environmental Reporting BC](http://www2.gov.bc.ca/gov/content?id=FF80E0B985F245CEA62808414D78C41B). Click [here](https://github.com/bcgov/EnvReportBC-RepoList) for a complete list of our repositories on GitHub.
+This repository is maintained by [Environmental Reporting
+BC](http://www2.gov.bc.ca/gov/content?id=FF80E0B985F245CEA62808414D78C41B).
+Click [here](https://github.com/bcgov/EnvReportBC-RepoList) for a
+complete list of our repositories on GitHub.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,7 +4,6 @@
 * local Windows 7, R 3.4.3
 * ubuntu 14.04 (on travis-ci), R 3.4.3
 * win-builder (R-devel)
-* Debian Linux, R-patched, GCC (on R-Hub)
 
 ## R CMD check results
 

--- a/man/raster_by_poly.Rd
+++ b/man/raster_by_poly.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/raster_by_poly.R
 \name{raster_by_poly}
 \alias{raster_by_poly}
-\title{Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer and clip the raster to each polygon.}
+\title{Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer
+and clip the raster to each polygon.}
 \usage{
 raster_by_poly(raster_layer, poly, poly_field, summarize = FALSE,
   parallel = FALSE, cores = NULL, ...)
@@ -14,17 +15,22 @@ raster_by_poly(raster_layer, poly, poly_field, summarize = FALSE,
 
 \item{poly_field}{the field on which to split the \code{SpatialPolygonsDataFrame}}
 
-\item{summarize}{Should the function summarise the raster values in each polygon to a vector? Default \code{FALSE}}
+\item{summarize}{Should the function summarise the raster values in each
+polygon to a vector? Default \code{FALSE}}
 
-\item{parallel}{process in parallel? Default \code{FALSE}}
+\item{parallel}{process in parallel? Default \code{FALSE}. Not currently
+available on Windows.}
 
-\item{cores}{number of cores if doing parallel. Default \code{NULL} uses half the number detected}
+\item{cores}{number of cores if doing parallel. Default \code{NULL} uses half the
+number detected}
 
 \item{...}{passed on to \code{doMC::registerDoMC}}
 }
 \value{
-a list of \code{RasterLayers} if \code{summarize = FALSE} otherwise a list of vectors.
+a list of \code{RasterLayers} if \code{summarize = FALSE} otherwise a list of
+vectors.
 }
 \description{
-Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer and clip the raster to each polygon.
+Overlay a SpatialPolygonsDataFrmae or sf polygons layer on a raster layer
+and clip the raster to each polygon.
 }

--- a/man/summarize_raster_list.Rd
+++ b/man/summarize_raster_list.Rd
@@ -9,9 +9,11 @@ summarize_raster_list(raster_list, parallel = FALSE, cores = NULL, ...)
 \arguments{
 \item{raster_list}{list of rasters}
 
-\item{parallel}{process in parallel? Default \code{FALSE}}
+\item{parallel}{process in parallel? Default \code{FALSE}. Not currently
+available on Windows.}
 
-\item{cores}{number of cores if doing parallel. Default \code{NULL} uses half the number detected}
+\item{cores}{number of cores if doing parallel. Default \code{NULL} uses half the
+number detected}
 
 \item{...}{passed on to \code{doMC::registerDoMC}}
 }


### PR DESCRIPTION
An upcoming [change in **raster**](https://github.com/rforge/raster/commit/df1da5be40df19da337213dfe67eb7bae836f184) was causing bcmaps to fail. This adds a small conditional check to make sure that `self_union()` works with the upcoming version of raster, but maintains backward compatibility with older versions of raster (Thanks @boshek). This commit (https://github.com/bcgov/bcmaps/commit/30cef3438268fba459c9c0c459cdb147ee9ccf75) is the meat of the change, the rest is other stuff just tidying and preparing for a CRAN release.