### PR TITLE
update README with updated reference to ggplot2

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -135,9 +135,8 @@ bec <- bec(force = TRUE, ask = FALSE)
 ```
 
 ```{r bec, message=FALSE}
-# This example requires the development version of ggplot2 which has the 
-# `geom_sf()` function:
-# remotes::install_github("tidyverse/ggplot2")
+# This example requires ggplot2 3.0.0 or greater, which has the 
+# `geom_sf()` function (see https://ggplot2.tidyverse.org/reference/ggsf.html):
 bec <- bec()
 library(ggplot2)
 ggplot() +


### PR DESCRIPTION
ggplot2 3.0.0 is the CRAN version that contains the geom_sf() function (as well as other related functions)