### PR TITLE
Future fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # bcmaps 0.18.1.9000
 - Adding forward sortation area, health boundaries and some census boundaries.
-
+- Use of parallelism in functions that allow it (`raster_by_poly()` & 
+`summarize_raster_list()`) is now reliant on users setting up their 
+own `future::plan()` to specify strategy and number of workers, rather than setting
+defaults (this is the best practice according to the author of the future package @HenrikBengtsson, #69)
 
 # bcmaps 0.18.1
 

--- a/man/raster_by_poly.Rd
+++ b/man/raster_by_poly.Rd
@@ -10,10 +10,7 @@ raster_by_poly(
   poly,
   poly_field,
   summarize = FALSE,
-  parallel = FALSE,
-  future_strategy = NULL,
-  workers = NULL,
-  ...
+  parallel = FALSE
 )
 }
 \arguments{
@@ -26,17 +23,9 @@ raster_by_poly(
 \item{summarize}{Should the function summarise the raster values in each
 polygon to a vector? Default \code{FALSE}}
 
-\item{parallel}{process in parallel? Default \code{FALSE}.}
-
-\item{future_strategy}{the strategy to use in \code{\link[future:plan]{future::plan()}} for parallel
-computation. Default \code{NULL} respects if user has already set a plan using
-\code{\link[future:plan]{future::plan()}} or an \link[future:future.options]{option},
-otherwise uses \code{"multiprocess"}.}
-
-\item{workers}{number of workers if doing parallel. Default \code{NULL} uses the
-default of the future strategy chosen (usually \code{\link[future:availableCores]{future::availableCores()}}).}
-
-\item{...}{passed on to \code{\link[future:plan]{future::plan()}}}
+\item{parallel}{process in parallel? Default \code{FALSE}. If \code{TRUE}, it is up to
+the user to call \code{\link[future:plan]{future::plan()}} (or set \link[future:future.options]{options})
+to specify what parallel strategy to use.}
 }
 \value{
 a list of \code{RasterLayers} if \code{summarize = FALSE} otherwise a list of

--- a/man/summarize_raster_list.Rd
+++ b/man/summarize_raster_list.Rd
@@ -4,28 +4,14 @@
 \alias{summarize_raster_list}
 \title{Summarize a list of rasters into a list of numeric vectors}
 \usage{
-summarize_raster_list(
-  raster_list,
-  parallel = FALSE,
-  future_strategy = NULL,
-  workers = NULL,
-  ...
-)
+summarize_raster_list(raster_list, parallel = FALSE)
 }
 \arguments{
 \item{raster_list}{list of rasters}
 
-\item{parallel}{process in parallel? Default \code{FALSE}.}
-
-\item{future_strategy}{the strategy to use in \code{\link[future:plan]{future::plan()}} for parallel
-computation. Default \code{NULL} respects if user has already set a plan using
-\code{\link[future:plan]{future::plan()}} or an \link[future:future.options]{option},
-otherwise uses \code{"multiprocess"}.}
-
-\item{workers}{number of workers if doing parallel. Default \code{NULL} uses the
-default of the future strategy chosen (usually \code{\link[future:availableCores]{future::availableCores()}}).}
-
-\item{...}{passed on to \code{\link[future:plan]{future::plan()}}}
+\item{parallel}{process in parallel? Default \code{FALSE}. If \code{TRUE}, it is up to
+the user to call \code{\link[future:plan]{future::plan()}} (or set \link[future:future.options]{options})
+to specify what parallel strategy to use.}
 }
 \value{
 a list of numeric vectors

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,13 +10,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-
-
-if (requireNamespace("future", quietly = TRUE)) {
-  omax_global_size <- getOption("future.globals.maxSize")
-  oplan <- future::plan()
-}
-
-
 bc_data_dir <- options('bcmaps.data_dir'= tempdir())
 silence_update_message_value <- options('silence_update_message' = TRUE)

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -10,13 +10,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-
-
-if (requireNamespace("future", quietly = TRUE)) {
-  options("future.globals.maxSize" = omax_global_size)
-  future::plan(oplan)
-}
-
-
-options('bcmaps.data_dir' = bc_data_dir)
-options('silence_update_message' = silence_update_message_value)
+options(bc_data_dir)
+options(silence_update_message_value)

--- a/tests/testthat/test-raster_by_poly.R
+++ b/tests/testthat/test-raster_by_poly.R
@@ -26,14 +26,11 @@ if (require("raster") && require("sp")) {
 
   test_that("raster_by_poly works with parallel", {
     skip_if_not_installed("future.apply")
-    # Ensure options that are changed inside the functions are restored
-    omax_global_size <- getOption("future.globals.maxSize")
-    oplan <- future::plan()
+    oplan <- future::plan(future::multisession(workers = ifelse(future::nbrOfWorkers() > 1L, 2L, 1L)))
     expect_equal(raster_by_poly(r, p, "name", parallel = TRUE), r_by_p)
     expect_equal(raster_by_poly(r, p, "name", summarize = TRUE, parallel = TRUE),
                  r_by_p_sum)
-    expect_equal(omax_global_size, getOption("future.globals.maxSize"))
-    expect_equal(class(future::plan()), class(oplan))
+    on.exit(future::plan(oplan), add = TRUE)
   })
 
   test_that("raster_by_poly fails when a name is NA", {
@@ -51,32 +48,3 @@ if (require("raster") && require("sp")) {
     expect_equal(lapply(ex, sort), unname(lapply(r_by_p_sum, sort)))
   })
 }
-
-test_that("setup_future works", {
-  skip_if_not_installed("future")
-  # Ensure options that are changed inside the functions are restored
-  omax_global_size <- getOption("future.globals.maxSize")
-  oplan <- future::plan()
-
-  # Tester function with which to call setup_future
-  z <- function(future_strategy = NULL, workers = NULL, ...)
-    setup_future(future_strategy, workers, ...)
-
-  # With NULL defaults
-  expect_message(z(), "Running in parallel using a 'multiprocess' strategy with ",
-                 future::availableCores(), " workers")
-  expect_equal(class(future::plan()), class(oplan))
-  expect_equal(omax_global_size, getOption("future.globals.maxSize"))
-
-  # Setting explicitly
-  expect_message(z("cluster", 2), "Running in parallel using a 'cluster' strategy with 2 workers")
-  expect_equal(class(future::plan()), class(oplan))
-  expect_equal(omax_global_size, getOption("future.globals.maxSize"))
-
-  # With having a pre-set plan
-  future::plan("multisession", workers = 2)
-  oplan <- future::plan()
-  expect_message(z(), "Running in parallel using a 'multisession' strategy with 2 workers")
-  expect_equal(future::plan(), oplan)
-  expect_equal(omax_global_size, getOption("future.globals.maxSize"))
-})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -35,13 +35,6 @@ test_that("bc_bbox works with all classes and numeric crs", {
   expect_equal(Extent_to_vec(bc_bbox("raster", crs = 4326)), sf_out)
 })
 
-test_that("bc_bbox works with all classes and character crs", {
-  skip_on_cran()
-  sf_out <- sf_bbox_to_vec(bc_bbox(crs = "+init=epsg:3857"))
-  expect_equal(sp_bbox_to_vec(bc_bbox("sp", crs = "+init=epsg:3857")), sf_out)
-  expect_equal(Extent_to_vec(bc_bbox("raster", crs = "+init=epsg:3857")), sf_out)
-})
-
 test_that("update_message_once warns once and only once", {
   options("silence_update_message" = FALSE)
   expect_message(update_message_once("artoo"))


### PR DESCRIPTION
This PR removes most of the plumbing that set up parallel parameters for the user, as recommended by the author of the `future` package. Now, a user must select a `future` strategy by way of the `future::plan()` function, before calling the functions that use parallel processing. 

So before it was:

```r
raster_by_poly(x, y, parallel = TRUE, future_strategy = "multisession", workers = 2)
```

Now it is:

```r
future::plan(multisession(workers = 2))
raster_by_poly(x, y, parallel = TRUE)
```

When bcmaps was taking care of the parallel setup, there was too much potential for conflicts if a user had already specified future parameters.