### PR TITLE
Pass `ask` arg from `cded_*()` to `vrt()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bcmaps (development version)
 
+* In the `cded_()` functions, the `ask` argument, which controls if
+  if the user is consulted to store data in the cache, was ignored. It is now respected (#147).
+
 # bcmaps 2.2.0
 
 * Added function `utm_convert()` to convert tabular data with X and Y coordinates
@@ -14,8 +17,8 @@
 
 ## Removal of `sp` and `raster` support
 
-We've removed support for the `sp` and `raster` packages, 
-especially those parts that require 
+We've removed support for the `sp` and `raster` packages,
+especially those parts that require
 the use of the `rgdal` and `rgeos` packages, which will be retired in October 2023. See the [r-spatial blog](https://r-spatial.org/r/2022/04/12/evolution.html) for details of this evolution.
 
 * Removed the `class` argument in all of the data download functions: `get_layer()` and all of the wrapper shortcuts such as `bc_bound()`, `census_tract()`, etc. These functions will now only return `sf` objects.
@@ -23,9 +26,9 @@ the use of the `rgdal` and `rgeos` packages, which will be retired in October 20
 * `fix_geo_problems()` is removed. For `sf` objects simply use `sf::st_make_valid()`
 * `self_union()` is removed. Use `raster::union()` for `SpatialPolygonsDataFrame`s, or `sf::st_union()` with `sf` objects instead.
 * `get_poly_attribute()` is removed.
-* `raster_by_poly()` is retained for now as it does not rely on `rgdal` or `rgeos`, 
+* `raster_by_poly()` is retained for now as it does not rely on `rgdal` or `rgeos`,
   just `sp` and `raster`, which are still being maintained.
-  
+
 ## Documentation improvements
 
 * Added a `pkgdown` site for `bcmaps` https://bcgov.github.io/bcmaps/ (#63)
@@ -36,16 +39,16 @@ the use of the `rgdal` and `rgeos` packages, which will be retired in October 20
 
 ## Deprecation of `sp` and `raster` support
 
-We've started the process of removing support for the `sp` and `raster` packages, 
-especially those parts of that require 
+We've started the process of removing support for the `sp` and `raster` packages,
+especially those parts of that require
 the use of the `rgdal` and `rgeos` packages, which will be retired in October 2023. See the [r-spatial blog](https://r-spatial.org/r/2022/04/12/evolution.html) for details of this evolution. We will fully remove
 support for `Spatial` classes (from package `sp`) in the next release in Summer 2023.
 
 * Added deprecation warnings for the `class` argument in all of the data download functions: `get_layer()` and all of the wrapper shortcuts such as `bc_bound()`, `census_tract()`, etc. This argument will be removed in the next version of `bcmaps` as these functions will only return `sf` objects.
 * The `Spatial` method of `transform_bc_albers()` is deprecated.
-* `fix_geo_problems()` is deprecated and will be removed completely in Summer 2023. 
+* `fix_geo_problems()` is deprecated and will be removed completely in Summer 2023.
 For `sf` objects simply use `sf::st_make_valid()`
-* `self_union()` is deprecated and will be removed in Summer 2023. Use `raster::union()` 
+* `self_union()` is deprecated and will be removed in Summer 2023. Use `raster::union()`
 for `SpatialPolygonsDataFrame`s, or `sf::st_union()` with `sf` objects instead.
 * `get_poly_attribute()` is deprecated because it had a very niche application for calculating attributes on a `SpatialPolygonsDataFrame`, which we are removing support for. It will be removed completely in Summer 2023.
 
@@ -82,29 +85,29 @@ the old cache location could run `bcmaps::delete_cache()` before updating to bcm
 
 # bcmaps 1.0
 
-- Drop dependency on {bcmapsdata} in favour of directly retrieving layers (where present) 
-from the B.C. Data Catalogue (via {bcdata}) and storing in a local cache. Some additional 
-layers are retrieved from Statistics Canada. 
+- Drop dependency on {bcmapsdata} in favour of directly retrieving layers (where present)
+from the B.C. Data Catalogue (via {bcdata}) and storing in a local cache. Some additional
+layers are retrieved from Statistics Canada.
 - Some layers may not be identical to what was previously in {bcmaps}. For example `bc_neighbours` previously used data from Natural Earth. The availability of a Hi-Res B.C. boundaries over WFS from the B.C. Data Catalogue means that the layer can now be created directly by {bcmaps}.
 - Added forward sortation area (`fsa`), health boundaries (`health_*`) and some census boundaries (`census_*`).
 - Added ability to retrieve and cache CDED ([BC Digital Elevation Model](https://catalogue.data.gov.bc.ca/dataset/digital-elevation-model-for-british-columbia-cded-1-250-000) data, returning either `stars` or `raster` objects (#73)
-- Use of parallelism in functions that allow it (`raster_by_poly()` & 
-`summarize_raster_list()`) is now reliant on users setting up their 
+- Use of parallelism in functions that allow it (`raster_by_poly()` &
+`summarize_raster_list()`) is now reliant on users setting up their
 own `future::plan()` to specify strategy and number of workers, rather than setting
 defaults (this is the best practice according to the author of the future package @HenrikBengtsson, #69)
 - Fixed bug where errors would occur if a user's system GEOS was a development version (e.g., 3.9.0dev; #71)
 
 # bcmaps 0.18.1
 
-* Fixed an error where `fix_geo_problems()` would fail depending on the version 
+* Fixed an error where `fix_geo_problems()` would fail depending on the version
 of `GEOS` upon which `sf` was built.
-* `raster_by_poly()` fails informatively when there are `NA` values in 
+* `raster_by_poly()` fails informatively when there are `NA` values in
 the column on which the polygons are to be split (#48, thanks @j-galloway)
 * `raster_by_poly()` (and `summarize_raster_list()`) now uses the
 [`future.apply`](https://cran.r-project.org/package=future.apply) package
 for parallelism, enabling easy parallelization across platforms (#49)
 * `get_layer()` (and in turn, any of the individual layer functions) now sets
-the `crs` so the `crs` representation will always be up to date with the user's 
+the `crs` so the `crs` representation will always be up to date with the user's
 `sf` version (#51, https://github.com/r-spatial/sf/issues/1225)
 
 # bcmaps 0.18.0
@@ -136,36 +139,36 @@ the `crs` so the `crs` representation will always be up to date with the user's
 
 
 # bcmaps 0.15.0
-* Added the ability to download Biogeoclimatic Zone map - as it was too big to 
-fit in the bcmaps.rdata package, it is hosted as an asset on a GitHub release of bcmaps.rdata, 
+* Added the ability to download Biogeoclimatic Zone map - as it was too big to
+fit in the bcmaps.rdata package, it is hosted as an asset on a GitHub release of bcmaps.rdata,
 and downloaded via the function `bec()`, which uses the new function `get_big_data()` (#28).
-* Added function `bec_colours()` (and alias `bec_colors()`) to generate a vector of colours 
+* Added function `bec_colours()` (and alias `bec_colors()`) to generate a vector of colours
 that match the standard colours used to colour Biogeoclimatic Zone maps.
 
 # bcmaps 0.14.0
-* Changed the lookup for exported objected to `getNamespaceExports("bcmaps")` so that you can 
+* Changed the lookup for exported objected to `getNamespaceExports("bcmaps")` so that you can
 call layers without loading the package via `bcmaps::`
 * Removed `watersheds` layer from package
 * Added `ecosections` to package
 
 # bcmaps 0.13.0
 
-This is a major new release with breaking changes. 
+This is a major new release with breaking changes.
 
-All data has been removed from the `bcmaps` package and moved to the `bcmaps.rdata` 
-package, which is hosted on the bcgov drat repository: https://github.com/bcgov/drat. 
-That package must be installed in order for `bcmaps` to access the data. It can 
+All data has been removed from the `bcmaps` package and moved to the `bcmaps.rdata`
+package, which is hosted on the bcgov drat repository: https://github.com/bcgov/drat.
+That package must be installed in order for `bcmaps` to access the data. It can
 be installed with: `install.packages('bcmaps.rdata', repos='https://bcgov.github.io/drat/')`
 
-In previous versions of `bcmaps`, data was stored in the package and loaded by 
+In previous versions of `bcmaps`, data was stored in the package and loaded by
 calling `data("layername")` or simply `layername` (e.g., `data("bc_bound")` or `bc_bound`).
 
 Now loading data requires a function call - either using a shortcut function that
-is the same name as the dataset (e.g., `bc_bound()` whereas previously one would 
-simply use `bc_bound`). Alternatively, one can use the `get_layer()` function 
+is the same name as the dataset (e.g., `bc_bound()` whereas previously one would
+simply use `bc_bound`). Alternatively, one can use the `get_layer()` function
 (e.g., `get_layer("bc_bound")`).
 
-Another major change is that all the layers are now returned as `sf` classes by 
+Another major change is that all the layers are now returned as `sf` classes by
 default, rather than `Spatial` classes. `Spatial` versions of the data can still be
 obtained by setting the `class` argument to `"sp"` in `get_layer()` and the shortcut
 functions (E.g., `bc_bound(class = "sp")` or `get_layer("bc_bound", class = "sp")`).

--- a/R/cded.R
+++ b/R/cded.R
@@ -107,7 +107,7 @@ cded_stars <- function(aoi = NULL, tiles_50K = NULL, .predicate = sf::st_interse
     tiles_50K = tiles_50K,
     .predicate = .predicate,
     dest_vrt = dest_vrt,
-    ask = interactive(),
+    ask = ask,
     check_tiles = check_tiles
   )
 
@@ -139,7 +139,7 @@ cded_terra <- function(aoi = NULL, tiles_50K = NULL, .predicate = sf::st_interse
     tiles_50K = tiles_50K,
     .predicate = .predicate,
     dest_vrt = dest_vrt,
-    ask = interactive(),
+    ask = ask,
     check_tiles = check_tiles
   )
 
@@ -183,7 +183,7 @@ cded_raster <- function(aoi = NULL, tiles_50K = NULL, .predicate = sf::st_inters
     tiles_50K = tiles_50K,
     .predicate = .predicate,
     dest_vrt = dest_vrt,
-    ask = interactive(),
+    ask = ask,
     check_tiles = check_tiles
   )
 


### PR DESCRIPTION
In each of the `cded_()` functions, the `ask` argument was not passed on to the call to `vrt()`, as it was hard-coded to `interactive()`. This keeps the default as `interactive()` in the user-facing call and respects that in the call to `vrt()`