### PR TITLE
Fix `utm_convert()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * In the `cded_()` functions, the `ask` argument, which controls if
   if the user is consulted to store data in the cache, was ignored. It is now respected (#147).
+* `utm_convert()` now respects `tibble` classes ([#143](https://github.com/bcgov/bcmaps/issues/143), #148).
+* Fixed a bug in `utm_convert()` where new coordinates could be mismatched with the wrong rows from the 
+  input data frame. ([#146](https://github.com/bcgov/bcmaps/issues/146), #148)
 
 # bcmaps 2.2.0
 

--- a/R/utm-convert.R
+++ b/R/utm-convert.R
@@ -53,23 +53,23 @@ utm_convert <- function(x, easting, northing, zone, crs = "EPSG:3005",
 
   if (one_zone) {
     res <- convert_from_zone(x, zone, easting, northing, crs, datum, xycols)
-    return(cbind(res, x[, setdiff(names(x), names(res))]))
+    return(res)
   }
-
-  x_split <- split(x, x[zone])
+  
+  x_split <- split(x, as.character(x[[zone]]))
 
   x_split <- lapply(x_split, function(z) {
     zone <- z[[zone]][1]
     convert_from_zone(z, zone, easting, northing, crs, datum, xycols)
   })
-
   res <- do.call("rbind", x_split)
-  cbind(res, x[, setdiff(names(x), names(res))])
+
+  restore_tibble(res, x)
 }
 
 convert_from_zone <- function(x, zone, easting, northing, crs, datum, xycols) {
   epsg <- lookup_epsg_code(zone, datum)
-  x <- sf::st_as_sf(x, coords = c(easting, northing), crs = epsg)
+  x <- sf::st_as_sf(x, coords = c(easting, northing), crs = epsg, remove = FALSE)
   res <- sf::st_transform(x, crs = crs)
   if (xycols) {
     res <- cbind(res, sf::st_coordinates(res))
@@ -100,4 +100,11 @@ format_zone <- function(x) {
     stop("Invalid zone(s): ", x, call. = FALSE)
   }
   ret
+}
+
+restore_tibble <- function(new, original) {
+  if (inherits(original, c("tbl_df", "tbl"))) {
+    class(new) <- c(setdiff(class(new), class(original)), class(original))
+  }
+  new
 }

--- a/R/utm-convert.R
+++ b/R/utm-convert.R
@@ -105,6 +105,8 @@ format_zone <- function(x) {
 restore_tibble <- function(new, original) {
   if (inherits(original, c("tbl_df", "tbl"))) {
     class(new) <- c(setdiff(class(new), class(original)), class(original))
+  } else {
+    rownames(new) <- rownames(original)
   }
   new
 }

--- a/tests/testthat/test-utm-convert.R
+++ b/tests/testthat/test-utm-convert.R
@@ -162,15 +162,19 @@ test_that("Output minus sf stuff is same as input (#146)", {
     sf::st_drop_geometry(out_tbl)[, setdiff(names(out_tbl), c("X", "Y", "geometry")), drop = FALSE]
   )
 
+  # Check with bare data frame with row names
+  data_df <- as.data.frame(data)
+  rownames(data_df) <- letters[seq_len(nrow(data_df))]
+
   out_df <- utm_convert(
-    as.data.frame(data),
+    data_df,
     easting = "UTMe",
     northing = "UTMn",
     zone = "Zone"
   )
-
+  
   expect_equal(
-    as.data.frame(data), 
+    data_df, 
     sf::st_drop_geometry(out_df)[, setdiff(names(out_df), c("X", "Y", "geometry")), drop = FALSE]
   )
 

--- a/tests/testthat/test-utm-convert.R
+++ b/tests/testthat/test-utm-convert.R
@@ -150,7 +150,7 @@ test_that("Output minus sf stuff is same as input (#146)", {
     )
   )
 
-  out <- utm_convert(
+  out_tbl <- utm_convert(
     data,
     easting = "UTMe",
     northing = "UTMn",
@@ -159,6 +159,19 @@ test_that("Output minus sf stuff is same as input (#146)", {
 
   expect_equal(
     data, 
-    sf::st_drop_geometry(out)[, setdiff(names(out), c("X", "Y", "geometry")), drop = FALSE]
+    sf::st_drop_geometry(out_tbl)[, setdiff(names(out_tbl), c("X", "Y", "geometry")), drop = FALSE]
   )
+
+  out_df <- utm_convert(
+    as.data.frame(data),
+    easting = "UTMe",
+    northing = "UTMn",
+    zone = "Zone"
+  )
+
+  expect_equal(
+    as.data.frame(data), 
+    sf::st_drop_geometry(out_df)[, setdiff(names(out_df), c("X", "Y", "geometry")), drop = FALSE]
+  )
+
 })

--- a/tests/testthat/test-utm-convert.R
+++ b/tests/testthat/test-utm-convert.R
@@ -95,3 +95,70 @@ test_that("utm_convert errors expectedly", {
   expect_error(utm_convert(df, "easting", "northing", "zone"), "Invalid zone")
 })
 
+test_that("Output minus sf stuff is same as input (#146)", {
+  data <- tibble::tibble(
+    Row_ID = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+    NotSure = c(9608, 9609, 9610, 9611, 9612, 9613, 9614, 9615, 9616, 9617),
+    Zone = c(10, 10, 10, 10, 10, 10, 9, 9, 9, 9),
+    UTMe = c(
+      361775,
+      361775,
+      307196,
+      307196,
+      328213,
+      328213,
+      636424,
+      636648,
+      636795,
+      637401
+    ),
+    UTMn = c(
+      6011950,
+      6011950,
+      5979777,
+      5979777,
+      5984261,
+      5984261,
+      6161177,
+      6161270,
+      6161127,
+      6160851
+    ),
+    UTMe1 = c(
+      361775,
+      361775,
+      307196,
+      307196,
+      328213,
+      328213,
+      636424,
+      636648,
+      636795,
+      637401
+    ),
+    UTMn1 = c(
+      6011950,
+      6011950,
+      5979777,
+      5979777,
+      5984261,
+      5984261,
+      6161177,
+      6161270,
+      6161127,
+      6160851
+    )
+  )
+
+  out <- utm_convert(
+    data,
+    easting = "UTMe",
+    northing = "UTMn",
+    zone = "Zone"
+  )
+
+  expect_equal(
+    data, 
+    sf::st_drop_geometry(out)[, setdiff(names(out), c("X", "Y", "geometry")), drop = FALSE]
+  )
+})

--- a/tests/testthat/test-utm-convert.R
+++ b/tests/testthat/test-utm-convert.R
@@ -96,7 +96,7 @@ test_that("utm_convert errors expectedly", {
 })
 
 test_that("Output minus sf stuff is same as input (#146)", {
-  data <- tibble::tibble(
+  data <- data.frame(
     Row_ID = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
     NotSure = c(9608, 9609, 9610, 9611, 9612, 9613, 9614, 9615, 9616, 9617),
     Zone = c(10, 10, 10, 10, 10, 10, 9, 9, 9, 9),
@@ -149,8 +149,9 @@ test_that("Output minus sf stuff is same as input (#146)", {
       6160851
     )
   )
+  rownames(data) <- letters[seq_len(nrow(data))]
 
-  out_tbl <- utm_convert(
+  out_df <- utm_convert(
     data,
     easting = "UTMe",
     northing = "UTMn",
@@ -159,23 +160,26 @@ test_that("Output minus sf stuff is same as input (#146)", {
 
   expect_equal(
     data, 
-    sf::st_drop_geometry(out_tbl)[, setdiff(names(out_tbl), c("X", "Y", "geometry")), drop = FALSE]
+    sf::st_drop_geometry(out_df)[, setdiff(names(out_df), c("X", "Y", "geometry")), drop = FALSE]
   )
 
-  # Check with bare data frame with row names
-  data_df <- as.data.frame(data)
-  rownames(data_df) <- letters[seq_len(nrow(data_df))]
+  # Check with tibble
+  data_tbl <- structure(data, class = c("tbl_df", "tbl", "data.frame"))
+  rownames(data_tbl) <- NULL
 
-  out_df <- utm_convert(
-    data_df,
+  out_tbl <- utm_convert(
+    data_tbl,
     easting = "UTMe",
     northing = "UTMn",
     zone = "Zone"
   )
   
+  expect_s3_class(out_tbl, "tbl_df")
+  
   expect_equal(
-    data_df, 
-    sf::st_drop_geometry(out_df)[, setdiff(names(out_df), c("X", "Y", "geometry")), drop = FALSE]
+    data_tbl, 
+    sf::st_drop_geometry(out_tbl)[, setdiff(names(out_tbl), c("X", "Y", "geometry")), drop = FALSE],
+    check.attributes = FALSE
   )
 
 })


### PR DESCRIPTION
This ensures that the output of `utm_convert()` is the same as the input, except with the new spatial information.

There were two main issues:
1. `split()` was splitting on a numeric column and thus was ordering the split sub data frames on that numeric, rather than respecting the order they were in in the original data.frame.
2. We were `cbind()`ing unnecessarily in the reassembled data frame, because that could have been (and is now) delegated to `convert_from_zone()` as it is run on each individual sub-dataframe separately.

The cbinding of the original data frame with the reassembled sub data frames (which were reassembled not in order) resulted in a mismatch of rows.

Now in each sub data frame we keep the input columns, and cbind `X` and `Y` if they are asked for, then reassemble the sub-dataframes, in the order they were in in the orginal input.

Finally, if an input was a `tibble`, it is now returned as a `tibble`.

Closes #146; closes #143 